### PR TITLE
Add automated Shopify bot skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SHOPIFY_API_KEY=your_shopify_api_key
+SHOPIFY_PASSWORD=your_shopify_password
+SHOPIFY_STORE_NAME=your_store_name
+PIXIAN_API_KEY=your_pixian_api_key

--- a/.github/workflows/run-bot.yml
+++ b/.github/workflows/run-bot.yml
@@ -1,0 +1,25 @@
+name: Run Bot
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install deps
+        run: npm install
+      - name: Run bot
+        env:
+          SHOPIFY_API_KEY: ${{ secrets.SHOPIFY_API_KEY }}
+          SHOPIFY_PASSWORD: ${{ secrets.SHOPIFY_PASSWORD }}
+          SHOPIFY_STORE_NAME: ${{ secrets.SHOPIFY_STORE_NAME }}
+          PIXIAN_API_KEY: ${{ secrets.PIXIAN_API_KEY }}
+        run: npm start

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+logs.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# ARZOLA-SCAPS-BOT
+# ARZOLA SCAPS BOT
+
+This repository contains an automation script that scrapes hat listings from **BigBossCaps** and publishes them to Shopify. Images are cleaned using the Pixian.AI service. The bot runs hourly via GitHub Actions.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your credentials.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the bot locally:
+   ```bash
+   npm start
+   ```
+
+The workflow in `.github/workflows/run-bot.yml` runs `npm start` every hour on GitHub Actions. Logs are saved to `logs.txt`.

--- a/bot/bot-bigbosscaps.js
+++ b/bot/bot-bigbosscaps.js
@@ -1,0 +1,182 @@
+/**
+ * BOT AUTOMATIZADO PARA SHOPIFY – EXTRAER GORRAS DE BigBossCaps
+ *
+ * 1. Usar Puppeteer o Axios/Cheerio para scrapear bigbosscaps.com:
+ *    - Recorrer todas las páginas de gorras.
+ *    - Para cada gorra obtener: nombre, precio original, URL de imágenes, colección (por ejemplo “Dandy Hats” si el nombre incluye esas palabras).
+ *    - Detectar si la gorra ya existe en Shopify (buscando por handle o SKU).
+ *
+ * 2. Para cada gorra nueva (no exista en Shopify):
+ *    a) Descargar todas las imágenes.
+ *    b) Llamar a un servicio de eliminación de marca de agua (por ejemplo, la API de Pixian.AI):
+ *       • Enviar cada imagen a Pixian.AI y recibir la imagen limpia sin marca de agua.
+ *    c) Calcular el precio de venta: precio_original + 1500 MXN.
+ *    d) Subir producto a Shopify usando Admin API (requiere API Key y password):
+ *       • title: nombre de la gorra.
+ *       • body_html: descripción (puede copiar la descripción de BigBossCaps si la hay).
+ *       • images: las URLs resultantes de Pixian.AI (subirlas a Shopify).
+ *       • variants:
+ *           – price: precio calculado.
+ *           – inventory_quantity: 50.
+ *           – inventory_management: “shopify”.
+ *       • tags/collections: asignar la colección según corresponda. Si el nombre incluye “Dandy Hats”, meterlo en la colección “Dandy Hats”.
+ *
+ * 3. Para cada gorra que ya exista en Shopify:
+ *    a) Comprobar el stock en BigBossCaps (por ejemplo, si en la ficha aparece “Agotado” o no hay stock visible).
+ *    b) Si está agotada en BigBossCaps, hacer un “UPDATE” vía API de Shopify para poner inventory_quantity en 0 y marcar como “sold out”.
+ *    c) Si vuelve a haber stock, actualizar inventory_quantity a 50 (o a la cantidad correcta).
+ *
+ * 4. Ejecutar este script cada hora:
+ *    • Configurar GitHub Actions (o un cron local) que corra `node bot-bigbosscaps.js` cada 60 min.
+ *    • Guardar logs de ejecución (puedes usar consola o escribir a un archivo `logs.txt`).
+ *
+ * 5. Manejo de errores:
+ *    • Si falla el scrapeo, reintentar 3 veces con retraso.
+ *    • Si falla la llamada a Shopify, loguear el error y seguir con el siguiente producto.
+ *
+ * 6. Variables de entorno necesarias (en un `.env`):
+ *    - SHOPIFY_API_KEY
+ *    - SHOPIFY_PASSWORD
+ *    - SHOPIFY_STORE_NAME
+ *    - PIXIAN_API_KEY
+ *
+ * 7. Estructura de carpetas sugerida:
+ *    /bot
+ *      │– bot-bigbosscaps.js       ← Aquí pega este comentario y deja que Copilot genere el código.
+ *      │– package.json
+ *      │– .env                    ← Llena con tus credenciales.
+ *      │– helpers/                 ← Si Copilot separa lógica (e.g., `shopify.js`, `scraper.js`).
+ *
+ * Con estos comentarios, Codex (vía Copilot) te completará:
+ *  - Importaciones (axios, puppeteer, dotenv, etc.).
+ *  - Funciones de scraping.
+ *  - Llamadas HTTP a la API de Shopify.
+ *  - Integración con Pixian.AI.
+ *  - Estructura de loop para revisar stock y actualizar.
+ *
+ * PASOS PARA USARLO EN VS CODE CON COPILOT:
+ * 1. Crea un repositorio nuevo y habilita GitHub Copilot.
+ * 2. Dentro, crea la carpeta `/bot` y el archivo `bot-bigbosscaps.js`.
+ * 3. Pega este bloque de comentarios EXACTO al inicio de `bot-bigbosscaps.js`.
+ * 4. Guarda el archivo. Copilot te sugerirá automáticamente el resto del código; acepta las sugerencias o pídele “generate the code”.
+ * 5. Revisa que en `package.json` estén las dependencias necesarias: `axios`, `cheerio` o `puppeteer`, `dotenv`, etc.
+ * 6. Configura en GitHub Actions un workflow `.github/workflows/run-bot.yml` que ejecute `node bot/bot-bigbosscaps.js` cada hora.
+ *
+ * De esta forma, Codex sabrá todo lo que debe hacer y generará el esqueleto completo. Luego tú solo revisas y afin­as detalles puntuales (por ejemplo, rutas específicas, nombres de variables).  
+ */
+
+// Load environment variables
+require('dotenv').config();
+const path = require('path');
+const fs = require('fs-extra');
+const axios = require('axios');
+const cheerio = require('cheerio');
+const FormData = require('form-data');
+
+const { uploadProduct, productExists, updateInventory } = require('./helpers/shopify');
+const { delay, downloadImage, log } = require('./helpers/utils');
+
+const BASE_URL = 'https://bigbosscaps.com';
+const START_PAGE = `${BASE_URL}/collections/gorras`; // example collection page
+
+async function fetchHTML(url) {
+  for (let i = 0; i < 3; i++) {
+    try {
+      const { data } = await axios.get(url);
+      return cheerio.load(data);
+    } catch (error) {
+      await delay(1000 * (i + 1));
+    }
+  }
+  throw new Error(`Failed to fetch ${url}`);
+}
+
+async function scrapeProducts() {
+  let page = 1;
+  let products = [];
+  while (true) {
+    const url = `${START_PAGE}?page=${page}`;
+    log(`Scraping ${url}`);
+    let $;
+    try {
+      $ = await fetchHTML(url);
+    } catch (err) {
+      log(`Error fetching ${url}: ${err.message}`);
+      break;
+    }
+
+    const items = $('.product-card');
+    if (!items.length) break;
+
+    items.each((_, el) => {
+      const name = $(el).find('.product-card__title').text().trim();
+      const price = $(el).find('.price').first().text().trim();
+      const handle = $(el).find('a').attr('href');
+      const img = $(el).find('img').attr('src');
+      products.push({ name, price, handle, img });
+    });
+    page++;
+  }
+  return products;
+}
+
+async function removeWatermark(filePath) {
+  const form = new FormData();
+  form.append('image', fs.createReadStream(filePath));
+  try {
+    const { data } = await axios.post('https://api.pixian.ai/remove', form, {
+      headers: {
+        'Authorization': `Bearer ${process.env.PIXIAN_API_KEY}`,
+        ...form.getHeaders(),
+      },
+    });
+    const outPath = filePath.replace(/(\.\w+)$/, '_clean$1');
+    await fs.writeFile(outPath, data);
+    return outPath;
+  } catch (err) {
+    log(`Pixian error: ${err.message}`);
+    return filePath;
+  }
+}
+
+async function processProduct(prod) {
+  const exists = await productExists(prod.handle);
+  if (exists) {
+    // check stock page
+    const $ = await fetchHTML(`${BASE_URL}${prod.handle}`);
+    const soldOut = $('button.sold-out, .sold-out').length > 0;
+    const qty = soldOut ? 0 : 50;
+    await updateInventory(exists.variantId, qty);
+    return;
+  }
+
+  const imgPath = await downloadImage(prod.img);
+  const cleanPath = await removeWatermark(imgPath);
+
+  const priceNumber = parseFloat(prod.price.replace(/[^\d.]/g, '')) + 1500;
+
+  await uploadProduct({
+    title: prod.name,
+    body_html: '',
+    images: [cleanPath],
+    price: priceNumber.toFixed(2),
+    tags: prod.name.includes('Dandy Hats') ? ['Dandy Hats'] : [],
+  });
+}
+
+async function main() {
+  try {
+    const products = await scrapeProducts();
+    for (const p of products) {
+      try {
+        await processProduct(p);
+      } catch (err) {
+        log(`Error processing ${p.name}: ${err.message}`);
+      }
+    }
+  } catch (err) {
+    log(`Fatal error: ${err.message}`);
+  }
+}
+
+main();

--- a/bot/helpers/scraper.js
+++ b/bot/helpers/scraper.js
@@ -1,0 +1,1 @@
+// Placeholder for additional scraper utilities if needed in the future

--- a/bot/helpers/shopify.js
+++ b/bot/helpers/shopify.js
@@ -1,0 +1,66 @@
+const axios = require('axios');
+const fs = require('fs-extra');
+const path = require('path');
+const { log } = require('./utils');
+
+const SHOP_URL = `https://${process.env.SHOPIFY_API_KEY}:${process.env.SHOPIFY_PASSWORD}` +
+  `@${process.env.SHOPIFY_STORE_NAME}.myshopify.com/admin/api/2023-10`;
+
+async function productExists(handle) {
+  try {
+    const url = `${SHOP_URL}/products.json?handle=${handle}`;
+    const { data } = await axios.get(url);
+    const product = data.products && data.products[0];
+    return product ? { id: product.id, variantId: product.variants[0].id } : null;
+  } catch (err) {
+    log(`Shopify check error: ${err.message}`);
+    return null;
+  }
+}
+
+async function uploadImage(filePath) {
+  const imageData = await fs.readFile(filePath, { encoding: 'base64' });
+  return { attachment: imageData };
+}
+
+async function uploadProduct({ title, body_html, images, price, tags }) {
+  try {
+    const imgs = [];
+    for (const imgPath of images) {
+      imgs.push(await uploadImage(imgPath));
+    }
+    const payload = {
+      product: {
+        title,
+        body_html,
+        tags: tags.join(', '),
+        images: imgs,
+        variants: [
+          {
+            price,
+            inventory_management: 'shopify',
+            inventory_quantity: 50
+          }
+        ]
+      }
+    };
+    const url = `${SHOP_URL}/products.json`;
+    const { data } = await axios.post(url, payload);
+    log(`Uploaded product ${title} with id ${data.product.id}`);
+  } catch (err) {
+    log(`Shopify upload error for ${title}: ${err.message}`);
+  }
+}
+
+async function updateInventory(variantId, quantity) {
+  try {
+    const url = `${SHOP_URL}/variants/${variantId}.json`;
+    const payload = { variant: { id: variantId, inventory_quantity: quantity } };
+    await axios.put(url, payload);
+    log(`Updated inventory for variant ${variantId} to ${quantity}`);
+  } catch (err) {
+    log(`Inventory update error: ${err.message}`);
+  }
+}
+
+module.exports = { uploadProduct, productExists, updateInventory };

--- a/bot/helpers/utils.js
+++ b/bot/helpers/utils.js
@@ -1,0 +1,34 @@
+const fs = require('fs-extra');
+const path = require('path');
+const axios = require('axios');
+
+const LOG_FILE = path.join(__dirname, '..', '..', 'logs.txt');
+
+function log(message) {
+  const line = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFileSync(LOG_FILE, line);
+  console.log(message);
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function downloadImage(url) {
+  const fileName = path.basename(url.split('?')[0]);
+  const filePath = path.join(__dirname, '..', '..', 'tmp', fileName);
+  await fs.ensureDir(path.dirname(filePath));
+  const writer = fs.createWriteStream(filePath);
+  const response = await axios({
+    url,
+    method: 'GET',
+    responseType: 'stream'
+  });
+  response.data.pipe(writer);
+  return new Promise((resolve, reject) => {
+    writer.on('finish', () => resolve(filePath));
+    writer.on('error', reject);
+  });
+}
+
+module.exports = { log, delay, downloadImage };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "arzola-scaps-bot",
+  "version": "1.0.0",
+  "description": "Automation bot for BigBossCaps to Shopify",
+  "main": "bot/bot-bigbosscaps.js",
+  "scripts": {
+    "start": "node bot/bot-bigbosscaps.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.1",
+    "cheerio": "^1.0.0-rc.12",
+    "dotenv": "^16.3.1",
+    "form-data": "^4.0.0",
+    "fs-extra": "^11.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add instructions and setup in README
- configure dependencies in `package.json`
- ignore environment files and logs
- add GitHub Actions workflow to run the bot hourly
- implement bot script and helper modules for scraping, watermark removal and Shopify integration
- provide example `.env` file

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683f7246338483278004637585071a86